### PR TITLE
Take query string from query field or from resourceQuery field

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const makeIdIterator = (prefix = 'v', i = 1) => ({ next: () => prefix + i++ })
 module.exports = function yamlLoader(src) {
   const { asJSON, asStream, namespace, ...options } = Object.assign(
     { prettyErrors: true },
-    getOptions(this)
+    getOptions({ query: this.query || this.resourceQuery })
   )
 
   // keep track of repeated object references


### PR DESCRIPTION
In webpack 4.46.0 this.query is nil, even though resourceQuery has a value 